### PR TITLE
Fix typo in settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,7 +72,7 @@ export class GallerySettingTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Gallery On Open Path Search')
             .setDesc(`The path from which to show images when the main gallery is opened. 
-            Setting it to \`/\` will show all iamges in the vault. 
+            Setting it to \`/\` will show all images in the vault. 
             Can be used to avoid the loading all images and affecting on open performance 
             (especially if vault has a huge amount of high quality images). 
             Setting it to an invalid path to have no images shown when gallery is opened.`)


### PR DESCRIPTION
I just spotted a simple typo of "iamges" instead of "images" in plugin's settings. Creating this PR to fix it.